### PR TITLE
Undefined index of $addons array

### DIFF
--- a/controllers/admin/AdminGamificationController.php
+++ b/controllers/admin/AdminGamificationController.php
@@ -154,7 +154,7 @@ class AdminGamificationController extends ModuleAdminController
                 $return['advices_premium_to_display']['advices'] = array($weighted_advices_array[$rand], $weighted_advices_array[$rand2]);
             } elseif (count($return['advices_premium_to_display']['advices']) > 0) {
                 $addons = Advice::getAddonsAdviceByIdTab((int)Tools::getValue('id_tab'));
-                $return['advices_premium_to_display']['advices'][] = $addons[0];
+                $return['advices_premium_to_display']['advices'][] = array_shift($addons);
             }
         }
         


### PR DESCRIPTION
my clean installation of PrestaShop 1.6.1.6 (PHP 7) sends an error to logs:

`PHP message: PHP Notice:  Undefined offset: 0 in /modules/gamification/controllers/admin/AdminGamificationController.php on line 157`

`$addons` has only index `1`
