### PR TITLE
Update min compatible version for 1.7.4.0

### DIFF
--- a/gamification.php
+++ b/gamification.php
@@ -45,7 +45,7 @@ class gamification extends Module
         $this->version = '2.0.1';
         $this->author = 'PrestaShop';
         $this->ps_versions_compliancy = array(
-            'min' => '1.7.0.0',
+            'min' => '1.7.4.0',
         );
 
         parent::__construct();


### PR DESCRIPTION
Last version of gamification is only compatible with PrestaShop 1.7.4.0. This PR update the version compliancy.