### PR TITLE
Fix trophy on sf pages

### DIFF
--- a/views/templates/hook/notification_bt.tpl
+++ b/views/templates/hook/notification_bt.tpl
@@ -29,7 +29,7 @@
 </script>
 <li id="gamification_notif" style="background:none" class="dropdown">
 	<a href="javascript:void(0);" class="dropdown-toggle gamification_notif" data-toggle="dropdown">
-		<img src="../modules/gamification/views/img/trophy.png" alt="{$notification|intval}"/>
+		<img src="{$link->getBaseLink()}modules/gamification/views/img/trophy.png" alt="{$notification|intval}"/>
 		<span id="gamification_notif_number_wrapper" class="notifs_badge">
 			<span id="gamification_notif_value">{$notification|intval}</span>
 		</span>


### PR DESCRIPTION
On pages working with URL rewriting, the image could not be found. That was cause by the path, always going in the parent folder instead of starting from the base path.

Example where the issue can be reproduced: http://localhost/PrestaShop/admin-dev/index.php/module/manage