### PR TITLE
 Made enable and disable update Tab status

### DIFF
--- a/gamification.php
+++ b/gamification.php
@@ -145,23 +145,12 @@ class gamification extends Module
 
     public function enable($force_all = false)
     {
-        return parent::enable($force_all) && $this->updateTabStatus(1);
+        return parent::enable($force_all) && Tab::enablingForModule($this->name);
     }
 
     public function disable($force_all = false)
     {
-        return parent::disable($force_all) && $this->updateTabStatus(0);
-    }
-
-    private function updateTabStatus($status)
-    {
-        $id_tab = (int)Tab::getIdFromClassName('AdminGamification');
-        if ($id_tab) {
-            $tab = new Tab($id_tab);
-            $tab->active = (int)$status;
-            return $tab->update();
-        }
-        return false;
+        return parent::disable($force_all) && Tab::disablingForModule($this->name);
     }
     
     public function getContent()

--- a/gamification.php
+++ b/gamification.php
@@ -143,6 +143,27 @@ class gamification extends Module
         }
     }
 
+    public function enable($force_all = false)
+    {
+        return parent::enable($force_all) && $this->updateTabStatus(1);
+    }
+
+    public function disable($force_all = false)
+    {
+        return parent::disable($force_all) && $this->updateTabStatus(0);
+    }
+
+    private function updateTabStatus($status)
+    {
+        $id_tab = (int)Tab::getIdFromClassName('AdminGamification');
+        if ($id_tab) {
+            $tab = new Tab($id_tab);
+            $tab->active = (int)$status;
+            return $tab->update();
+        }
+        return false;
+    }
+    
     public function getContent()
     {
         Tools::redirectAdmin($this->context->link->getAdminLink('AdminGamification'));


### PR DESCRIPTION
Before when disabling gamification the menu link in the BO menu
would still be there but leading to a page without any active controller.
This commit rectifies that and switches the Tab status upon enable or disable.