### PR TITLE
Add lazy native attribute to images to avoid loading when hidden

### DIFF
--- a/views/templates/admin/gamification/helpers/view/view.tpl
+++ b/views/templates/admin/gamification/helpers/view/view.tpl
@@ -75,7 +75,7 @@
 
 {foreach from=$badges_type key=key item=type}
 <fieldset>
-    <legend><img src="../modules/gamification/views/img/{$key}.png" alt="{$type.name|escape:html:'UTF-8'}" /> {$type.name|escape:html:'UTF-8'}</legend>
+    <legend><img src="../modules/gamification/views/img/{$key}.png" alt="{$type.name|escape:html:'UTF-8'}" loading="lazy" /> {$type.name|escape:html:'UTF-8'}</legend>
     {include file='./filters.tpl' type=$key}
     <ul class="badge_list" id="list_{$key}" style="">
         {foreach from=$type.badges item=badge}

--- a/views/templates/admin/gamification/helpers/view/view_bt.tpl
+++ b/views/templates/admin/gamification/helpers/view/view_bt.tpl
@@ -97,7 +97,7 @@
                 <ul class="badge_list" id="list_{$key}" style="">
                     {foreach from=$type.badges item=badge}
                     <li class="badge_square badge_all {if $badge->validated}validated {else} not_validated{/if} group_{$badge->id_group} level_{$badge->group_position} " id="{$badge->id|intval}">
-                        <div class="gamification_badges_img" data-placement="top" data-toggle="tooltip" data-original-title="{$badge->description|escape:html:'UTF-8'}"><img src="{$badge->getBadgeImgUrl()}" alt="{$badge->name|escape:html:'UTF-8'}" /></div>
+                        <div class="gamification_badges_img" data-placement="top" data-toggle="tooltip" data-original-title="{$badge->description|escape:html:'UTF-8'}"><img src="{$badge->getBadgeImgUrl()}" alt="{$badge->name|escape:html:'UTF-8'}" loading="lazy" /></div>
                         <div class="gamification_badges_name">{$badge->name|escape:html:'UTF-8'}</div>
                     </li>
                     {foreachelse}

--- a/views/templates/hook/notification.tpl
+++ b/views/templates/hook/notification.tpl
@@ -28,7 +28,7 @@
 					<li class="{if $badge->validated} unlocked {else} locked {/if}" style="float:left;">
 						<span class="{if $badge->validated} unlocked_img {else} locked_img {/if}"></span>
 						<div class="gamification_badges_title"><span>{if $badge->validated} {l s='Last badge:' mod='gamification'} {else} {l s='Next badge:' mod='gamification'} {/if}</span></div>
-						<div class="gamification_badges_img"><img src="{$badge->getBadgeImgUrl()}"></div>
+						<div class="gamification_badges_img"><img src="{$badge->getBadgeImgUrl()}" loading="lazy"></div>
 						<div class="gamification_badges_name">{$badge->name|escape:html:'UTF-8'}</div>
 					</li>
 				{else}

--- a/views/templates/hook/notification_bt.tpl
+++ b/views/templates/hook/notification_bt.tpl
@@ -66,7 +66,7 @@
 							<li class="{if $badge->validated} unlocked {else} locked {/if}" style="float:left;">
 								<span class="{if $badge->validated} unlocked_img {else} locked_img {/if}" {if $badge->validated}style="left: 12px;"{/if}></span>
 								<div class="gamification_badges_title"><span>{if $badge->validated} {l s='Last badge:' mod='gamification'} {else} {l s='Next badge:' mod='gamification'} {/if}</span></div>
-								<div class="gamification_badges_img" data-placement="{if $i <= 1}bottom{else}top{/if}" data-original-title="{$badge->description|escape:html:'UTF-8'}"><img src="{$badge->getBadgeImgUrl()}"></div>
+								<div class="gamification_badges_img" data-placement="{if $i <= 1}bottom{else}top{/if}" data-original-title="{$badge->description|escape:html:'UTF-8'}"><img src="{$badge->getBadgeImgUrl()}" loading="lazy"></div>
 								<div class="gamification_badges_name">{$badge->name|escape:html:'UTF-8'}</div>
 							</li>
 						{/if}
@@ -80,7 +80,7 @@
 							<li class="{if $badge->validated} unlocked {else} locked {/if}" style="float:left;">
 								<span class="{if $badge->validated} unlocked_img {else} locked_img {/if}" {if $badge->validated}style="left: 12px;"{/if}></span>
 								<div class="gamification_badges_title"><span>{if $badge->validated} {l s='Last badge:' mod='gamification'} {else} {l s='Next badge:' mod='gamification'} {/if}</span></div>
-								<div class="gamification_badges_img" data-placement="{if $i <= 1}bottom{else}top{/if}"data-toggle="tooltip" data-original-title="{$badge->description|escape:html:'UTF-8'}"><img src="{$badge->getBadgeImgUrl()}"></div>
+								<div class="gamification_badges_img" data-placement="{if $i <= 1}bottom{else}top{/if}"data-toggle="tooltip" data-original-title="{$badge->description|escape:html:'UTF-8'}"><img src="{$badge->getBadgeImgUrl()}" loading="lazy"></div>
 								<div class="gamification_badges_name">{$badge->name|escape:html:'UTF-8'}</div>
 							</li>
 						{/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | On PS Dashboard, images were loaded even if they were hidden, adding this attribute permit to load images only when the module is shown
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Go on the PS dashboard (every version) with this module, open network tab when you load the page (on chrome especially), you shouldn't see some images like 8_1.png coming from the gamification module, and when you click on the trophy icon, you should see some images loading !

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
